### PR TITLE
✨ [Feat] Kinfisher를 사용하여 이미지 다운로드 및 캐싱 서비스 제작

### DIFF
--- a/EatPic-iOS/Sources/Common/Protocol/Services/ImageLoaderService.swift
+++ b/EatPic-iOS/Sources/Common/Protocol/Services/ImageLoaderService.swift
@@ -1,0 +1,39 @@
+//
+//  ImageLoaderService.swift
+//  EatPic-iOS
+//
+//  Created by jaewon Lee on 8/5/25.
+//
+
+import Foundation
+
+protocol ImageLoaderService {
+    var state: ImageLoadState { get }
+    
+    /// 네트워크를 통해 이미지를 비동기적으로 로드하고, 상태를 업데이트합니다.
+    ///
+    /// - Parameters:
+    ///   - urlString: 로드할 이미지의 URL 문자열입니다. 유효하지 않은 URL인 경우 `state`는 `.failure`로 설정됩니다.
+    ///
+    /// Kingfisher를 사용하여 이미지 로드를 수행하며, 다음과 같은 옵션이 적용됩니다
+    /// - `cacheOriginalImage`: 원본 이미지를 디스크 캐시에 저장하여 재사용 성능을 높입니다.
+    /// - `DownsamplingImageProcessor(size: 400x400)`: 메모리 최적화를 위해 이미지를 400x400 크기로 다운샘플링합니다.
+    ///   이는 피그마 디자인 기준으로 가장 큰 이미지가 361x361인 점을 반영하여, 적절한 품질을 유지하면서도 성능을 개선하기 위한 설정입니다.
+    /// - `scaleFactor`: 디스플레이 스케일에 맞게 이미지를 처리합니다.
+    /// - `transition(.fade(0.2))`: 이미지 전환 시 페이드 인 효과를 적용하여 자연스러운 UX를 제공합니다.
+    ///
+    /// 이미지 로딩 결과는 내부 상태 프로퍼티인 `state`를 통해 `.loading`, `.success(UIImage)`, `.failure(Error)` 형태로 외부에 전달됩니다.
+    ///
+    /// - Note: 이미지 로딩이 시작되면 기존 다운로드 작업은 취소되지 않으며, 새로운 작업이 `currentTask`에 저장됩니다.
+    ///   필요한 경우 `cancel()` 메서드를 통해 취소할 수 있습니다.
+    func loadImage(from urlString: String?) async
+    
+    /// 현재 진행 중인 이미지 다운로드 작업을 취소합니다.
+    ///
+    /// `loadImage(from:)`를 통해 이미지 다운로드가 시작된 이후,
+    /// 해당 작업을 중단하고자 할 경우 이 메서드를 호출할 수 있습니다.
+    ///
+    /// 호출 시 내부적으로 `Kingfisher.DownloadTask.cancel()`이 실행되며,
+    /// `currentTask`는 nil로 초기화됩니다.
+    func cancel()
+}

--- a/EatPic-iOS/Sources/Common/State/ImageLoadState.swift
+++ b/EatPic-iOS/Sources/Common/State/ImageLoadState.swift
@@ -1,0 +1,24 @@
+//
+//  ImageLoadState.swift
+//  EatPic-iOS
+//
+//  Created by jaewon Lee on 8/5/25.
+//
+
+import UIKit
+
+/// 이미지 로딩의 상태를 나타내는 열거형입니다.
+///
+/// 이 상태는 `ImageLoaderService`가 이미지 로딩 과정을 추적하고,
+/// 뷰에서 UI 상태를 동기화할 수 있도록 하기 위해 사용됩니다.
+///
+/// - idle: 이미지 로딩이 시작되지 않은 초기 상태입니다.
+/// - loading: 이미지가 네트워크에서 로딩 중인 상태입니다.
+/// - success(UIImage): 이미지 로딩이 성공하여, UIImage 객체를 포함하는 상태입니다.
+/// - failure(Error): 이미지 로딩이 실패한 상태이며, 실패 원인을 담은 Error 객체를 포함합니다.
+enum ImageLoadState {
+    case idle
+    case loading
+    case success(UIImage)
+    case failure(Error)
+}

--- a/EatPic-iOS/Sources/Components/Image/NetworkImageView.swift
+++ b/EatPic-iOS/Sources/Components/Image/NetworkImageView.swift
@@ -49,6 +49,7 @@ struct NetworkImageView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
             case .failure:
+                // TODO: [25.08.06] 이미지 로드 실패 이미지로 대체 예정 - 리버/이재원
                 Text("이미지 로드 실패")
             }
         }

--- a/EatPic-iOS/Sources/Core/Image/ImageLoaderServiceImpl.swift
+++ b/EatPic-iOS/Sources/Core/Image/ImageLoaderServiceImpl.swift
@@ -16,14 +16,15 @@ enum ImageLoadState {
     case failure(Error)
 }
 
-protocol ImageLoaderService: ObservableObject {
+protocol ImageLoaderService {
     var state: ImageLoadState { get }
     func loadImage(from urlString: String?)
     func cancel()
 }
 
+@Observable
 final class ImageLoaderServiceImpl: ImageLoaderService {
-    @Published private(set) var state: ImageLoadState = .idle
+    private(set) var state: ImageLoadState = .idle
     private var currentTask: DownloadTask?
     
     func loadImage(from urlString: String?) {

--- a/EatPic-iOS/Sources/Core/Image/ImageLoaderServiceImpl.swift
+++ b/EatPic-iOS/Sources/Core/Image/ImageLoaderServiceImpl.swift
@@ -1,0 +1,61 @@
+//
+//  ImageLoaderServiceImpl.swift
+//  EatPic-iOS
+//
+//  Created by jaewon Lee on 8/5/25.
+//
+
+import UIKit
+import Combine
+import Kingfisher
+
+enum ImageLoadState {
+    case idle
+    case loading
+    case success(UIImage)
+    case failure(Error)
+}
+
+protocol ImageLoaderService: ObservableObject {
+    var state: ImageLoadState { get }
+    func loadImage(from urlString: String?)
+    func cancel()
+}
+
+final class ImageLoaderServiceImpl: ImageLoaderService {
+    @Published private(set) var state: ImageLoadState = .idle
+    private var currentTask: DownloadTask?
+    
+    func loadImage(from urlString: String?) {
+        guard let urlString = urlString, let url = URL(string: urlString) else {
+            self.state = .failure(URLError(.badURL))
+            return
+        }
+        
+        state = .loading
+        
+        let options: KingfisherOptionsInfo = [
+            .cacheOriginalImage,
+            .transition(.fade(0.2)),
+            .processor(DownsamplingImageProcessor(size: CGSize(width: 400, height: 400))),
+            .scaleFactor(UIScreen.main.scale),
+            .cacheSerializer(DefaultCacheSerializer.default)
+        ]
+        
+        currentTask = KingfisherManager.shared
+            .retrieveImage(with: url, options: options) { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let retrieveResult):
+                    self.state = .success(retrieveResult.image)
+                case .failure(let error):
+                    self.state = .failure(error)
+                }
+        }
+    }
+    
+    func cancel() {
+        currentTask?.cancel()
+        currentTask = nil
+    }
+}

--- a/EatPic-iOS/Sources/Core/Image/ImageLoaderServiceImpl.swift
+++ b/EatPic-iOS/Sources/Core/Image/ImageLoaderServiceImpl.swift
@@ -9,6 +9,15 @@ import UIKit
 import Combine
 import Kingfisher
 
+/// 이미지 로딩의 상태를 나타내는 열거형입니다.
+///
+/// 이 상태는 `ImageLoaderService`가 이미지 로딩 과정을 추적하고,
+/// 뷰에서 UI 상태를 동기화할 수 있도록 하기 위해 사용됩니다.
+///
+/// - idle: 이미지 로딩이 시작되지 않은 초기 상태입니다.
+/// - loading: 이미지가 네트워크에서 로딩 중인 상태입니다.
+/// - success(UIImage): 이미지 로딩이 성공하여, UIImage 객체를 포함하는 상태입니다.
+/// - failure(Error): 이미지 로딩이 실패한 상태이며, 실패 원인을 담은 Error 객체를 포함합니다.
 enum ImageLoadState {
     case idle
     case loading
@@ -18,7 +27,32 @@ enum ImageLoadState {
 
 protocol ImageLoaderService {
     var state: ImageLoadState { get }
+    
+    /// 네트워크를 통해 이미지를 비동기적으로 로드하고, 상태를 업데이트합니다.
+    ///
+    /// - Parameters:
+    ///   - urlString: 로드할 이미지의 URL 문자열입니다. 유효하지 않은 URL인 경우 `state`는 `.failure`로 설정됩니다.
+    ///
+    /// Kingfisher를 사용하여 이미지 로드를 수행하며, 다음과 같은 옵션이 적용됩니다
+    /// - `cacheOriginalImage`: 원본 이미지를 디스크 캐시에 저장하여 재사용 성능을 높입니다.
+    /// - `DownsamplingImageProcessor(size: 400x400)`: 메모리 최적화를 위해 이미지를 400x400 크기로 다운샘플링합니다.
+    ///   이는 피그마 디자인 기준으로 가장 큰 이미지가 361x361인 점을 반영하여, 적절한 품질을 유지하면서도 성능을 개선하기 위한 설정입니다.
+    /// - `scaleFactor`: 디스플레이 스케일에 맞게 이미지를 처리합니다.
+    /// - `transition(.fade(0.2))`: 이미지 전환 시 페이드 인 효과를 적용하여 자연스러운 UX를 제공합니다.
+    ///
+    /// 이미지 로딩 결과는 내부 상태 프로퍼티인 `state`를 통해 `.loading`, `.success(UIImage)`, `.failure(Error)` 형태로 외부에 전달됩니다.
+    ///
+    /// - Note: 이미지 로딩이 시작되면 기존 다운로드 작업은 취소되지 않으며, 새로운 작업이 `currentTask`에 저장됩니다.
+    ///   필요한 경우 `cancel()` 메서드를 통해 취소할 수 있습니다.
     func loadImage(from urlString: String?)
+    
+    /// 현재 진행 중인 이미지 다운로드 작업을 취소합니다.
+    ///
+    /// `loadImage(from:)`를 통해 이미지 다운로드가 시작된 이후,
+    /// 해당 작업을 중단하고자 할 경우 이 메서드를 호출할 수 있습니다.
+    ///
+    /// 호출 시 내부적으로 `Kingfisher.DownloadTask.cancel()`이 실행되며,
+    /// `currentTask`는 nil로 초기화됩니다.
     func cancel()
 }
 
@@ -38,6 +72,7 @@ final class ImageLoaderServiceImpl: ImageLoaderService {
         let options: KingfisherOptionsInfo = [
             .cacheOriginalImage,
             .transition(.fade(0.2)),
+            // 400으로 고정한 이유는, 피그마 디자인상 이보다 더 큰 이미지가 존재하지 않기 때문.
             .processor(DownsamplingImageProcessor(size: CGSize(width: 400, height: 400))),
             .scaleFactor(UIScreen.main.scale),
             .cacheSerializer(DefaultCacheSerializer.default)

--- a/EatPic-iOS/Sources/Core/Image/ImageLoaderServiceImpl.swift
+++ b/EatPic-iOS/Sources/Core/Image/ImageLoaderServiceImpl.swift
@@ -9,59 +9,12 @@ import UIKit
 import Combine
 import Kingfisher
 
-/// 이미지 로딩의 상태를 나타내는 열거형입니다.
-///
-/// 이 상태는 `ImageLoaderService`가 이미지 로딩 과정을 추적하고,
-/// 뷰에서 UI 상태를 동기화할 수 있도록 하기 위해 사용됩니다.
-///
-/// - idle: 이미지 로딩이 시작되지 않은 초기 상태입니다.
-/// - loading: 이미지가 네트워크에서 로딩 중인 상태입니다.
-/// - success(UIImage): 이미지 로딩이 성공하여, UIImage 객체를 포함하는 상태입니다.
-/// - failure(Error): 이미지 로딩이 실패한 상태이며, 실패 원인을 담은 Error 객체를 포함합니다.
-enum ImageLoadState {
-    case idle
-    case loading
-    case success(UIImage)
-    case failure(Error)
-}
-
-protocol ImageLoaderService {
-    var state: ImageLoadState { get }
-    
-    /// 네트워크를 통해 이미지를 비동기적으로 로드하고, 상태를 업데이트합니다.
-    ///
-    /// - Parameters:
-    ///   - urlString: 로드할 이미지의 URL 문자열입니다. 유효하지 않은 URL인 경우 `state`는 `.failure`로 설정됩니다.
-    ///
-    /// Kingfisher를 사용하여 이미지 로드를 수행하며, 다음과 같은 옵션이 적용됩니다
-    /// - `cacheOriginalImage`: 원본 이미지를 디스크 캐시에 저장하여 재사용 성능을 높입니다.
-    /// - `DownsamplingImageProcessor(size: 400x400)`: 메모리 최적화를 위해 이미지를 400x400 크기로 다운샘플링합니다.
-    ///   이는 피그마 디자인 기준으로 가장 큰 이미지가 361x361인 점을 반영하여, 적절한 품질을 유지하면서도 성능을 개선하기 위한 설정입니다.
-    /// - `scaleFactor`: 디스플레이 스케일에 맞게 이미지를 처리합니다.
-    /// - `transition(.fade(0.2))`: 이미지 전환 시 페이드 인 효과를 적용하여 자연스러운 UX를 제공합니다.
-    ///
-    /// 이미지 로딩 결과는 내부 상태 프로퍼티인 `state`를 통해 `.loading`, `.success(UIImage)`, `.failure(Error)` 형태로 외부에 전달됩니다.
-    ///
-    /// - Note: 이미지 로딩이 시작되면 기존 다운로드 작업은 취소되지 않으며, 새로운 작업이 `currentTask`에 저장됩니다.
-    ///   필요한 경우 `cancel()` 메서드를 통해 취소할 수 있습니다.
-    func loadImage(from urlString: String?)
-    
-    /// 현재 진행 중인 이미지 다운로드 작업을 취소합니다.
-    ///
-    /// `loadImage(from:)`를 통해 이미지 다운로드가 시작된 이후,
-    /// 해당 작업을 중단하고자 할 경우 이 메서드를 호출할 수 있습니다.
-    ///
-    /// 호출 시 내부적으로 `Kingfisher.DownloadTask.cancel()`이 실행되며,
-    /// `currentTask`는 nil로 초기화됩니다.
-    func cancel()
-}
-
 @Observable
 final class ImageLoaderServiceImpl: ImageLoaderService {
     private(set) var state: ImageLoadState = .idle
     private var currentTask: DownloadTask?
     
-    func loadImage(from urlString: String?) {
+    func loadImage(from urlString: String?) async {
         guard let urlString = urlString, let url = URL(string: urlString) else {
             self.state = .failure(URLError(.badURL))
             return
@@ -69,7 +22,7 @@ final class ImageLoaderServiceImpl: ImageLoaderService {
         
         state = .loading
         
-        let options: KingfisherOptionsInfo = [
+        let options: KingfisherOptionsInfo = await [
             .cacheOriginalImage,
             .transition(.fade(0.2)),
             // 400으로 고정한 이유는, 피그마 디자인상 이보다 더 큰 이미지가 존재하지 않기 때문.
@@ -78,15 +31,33 @@ final class ImageLoaderServiceImpl: ImageLoaderService {
             .cacheSerializer(DefaultCacheSerializer.default)
         ]
         
-        currentTask = KingfisherManager.shared
-            .retrieveImage(with: url, options: options) { [weak self] result in
-                guard let self = self else { return }
-                switch result {
-                case .success(let retrieveResult):
-                    self.state = .success(retrieveResult.image)
-                case .failure(let error):
-                    self.state = .failure(error)
+        do {
+            let image = try await retrieveImageAsync(with: url, options: options)
+            self.state = .success(image)
+        } catch {
+            self.state = .failure(error)
+        }
+        
+    }
+    
+    /// `KingfisherManager`의 클로저 기반 `retrieveImage`를 async/await 방식으로 래핑합니다.
+    private func retrieveImageAsync(
+        with url: URL,
+        options: KingfisherOptionsInfo
+    ) async throws -> UIImage {
+        try await withCheckedThrowingContinuation { continuation in
+            currentTask = KingfisherManager.shared.retrieveImage(
+                with: url,
+                options: options,
+                completionHandler: { result in
+                    switch result {
+                    case .success(let value):
+                        continuation.resume(returning: value.image)
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    }
                 }
+            )
         }
     }
     

--- a/EatPic-iOS/Sources/Core/Image/NetworkImageView.swift
+++ b/EatPic-iOS/Sources/Core/Image/NetworkImageView.swift
@@ -7,10 +7,30 @@
 
 import SwiftUI
 
+/// 네트워크 상의 이미지를 비동기적으로 로드하여 화면에 표시하는 뷰입니다.
+///
+/// 내부적으로 `ImageLoaderService`를 통해 이미지를 가져오며,
+/// 이미지 상태에 따라 `ProgressView`, 성공 이미지, 실패 텍스트를 자동으로 렌더링합니다.
+///
+/// ```swift
+/// NetworkImageView(url: "https://example.com/image.jpg")
+/// ```
+///
+/// - Note: 이미지 로드 상태가 `.loading`, `.success`, `.failure`에 따라 다른 뷰를 보여줍니다.
 struct NetworkImageView: View {
+    
+    /// 이미지 로딩을 담당하는 서비스 객체입니다.
+    /// 기본적으로 `ImageLoaderServiceImpl()`을 사용하지만, 테스트나 확장을 위해 주입 가능합니다.
     @State private var loader: any ImageLoaderService
+    
+    /// 로딩할 이미지의 URL입니다. `nil`인 경우 로딩 시도는 무시됩니다.
     private let url: String?
     
+    /// `NetworkImageView`의 이니셜라이저입니다.
+    ///
+    /// - Parameters:
+    ///   - url: 로드할 이미지의 URL 문자열
+    ///   - loader: `ImageLoaderService` 구현체. 기본값은 `ImageLoaderServiceImpl()`
     init(
         url: String?,
         loader: @autoclosure @escaping () -> any ImageLoaderService = ImageLoaderServiceImpl()
@@ -18,6 +38,7 @@ struct NetworkImageView: View {
         _loader = .init(initialValue: loader())
         self.url = url
     }
+    
     var body: some View {
         Group {
             switch loader.state {

--- a/EatPic-iOS/Sources/Core/Image/NetworkImageView.swift
+++ b/EatPic-iOS/Sources/Core/Image/NetworkImageView.swift
@@ -1,0 +1,41 @@
+//
+//  NetworkImageView.swift
+//  EatPic-iOS
+//
+//  Created by jaewon Lee on 8/5/25.
+//
+
+import SwiftUI
+
+struct NetworkImageView: View {
+    @State private var loader: any ImageLoaderService
+    private let url: String?
+    
+    init(
+        url: String?,
+        loader: @autoclosure @escaping () -> any ImageLoaderService = ImageLoaderServiceImpl()
+    ) {
+        _loader = .init(initialValue: loader())
+        self.url = url
+    }
+    var body: some View {
+        Group {
+            switch loader.state {
+            case .idle, .loading:
+                ProgressView("로딩 중")
+            case .success(let image):
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            case .failure:
+                Text("이미지 로드 실패")
+            }
+        }
+        .onAppear {
+            loader.loadImage(from: url)
+        }
+        .onDisappear {
+            loader.cancel()
+        }
+    }
+}

--- a/EatPic-iOS/Sources/Core/Image/NetworkImageView.swift
+++ b/EatPic-iOS/Sources/Core/Image/NetworkImageView.swift
@@ -52,8 +52,8 @@ struct NetworkImageView: View {
                 Text("이미지 로드 실패")
             }
         }
-        .onAppear {
-            loader.loadImage(from: url)
+        .task {
+            await loader.loadImage(from: url)
         }
         .onDisappear {
             loader.cancel()

--- a/EatPic-iOS/Tests/Image/ImageLoaderServiceTest.swift
+++ b/EatPic-iOS/Tests/Image/ImageLoaderServiceTest.swift
@@ -25,7 +25,7 @@ struct ImageLoaderServiceTest {
                 """
         
         // when
-        loader.loadImage(from: urlString)
+        await loader.loadImage(from: urlString)
         try await Task.sleep(nanoseconds: 2_000_000_000)
         
         // then
@@ -38,12 +38,12 @@ struct ImageLoaderServiceTest {
     }
 
     @Test("잘못된 URL을 입력하면 failure 상태가 되어야 한다.")
-    func testInvalidURL() {
+    func testInvalidURL() async {
         // given
         let loader = ImageLoaderServiceImpl()
         
         // when
-        loader.loadImage(from: "valid url")
+        await loader.loadImage(from: "valid url")
         
         // then
         switch loader.state {
@@ -68,7 +68,7 @@ struct ImageLoaderServiceTest {
         }
         try await cache.store(dummyImage, forKey: testKey)
         
-        loader.loadImage(from: testKey)
+        await loader.loadImage(from: testKey)
         
         try await Task.sleep(nanoseconds: 1_000_000_000)
         

--- a/EatPic-iOS/Tests/Image/ImageLoaderServiceTest.swift
+++ b/EatPic-iOS/Tests/Image/ImageLoaderServiceTest.swift
@@ -48,7 +48,7 @@ struct ImageLoaderServiceTest {
         // then
         switch loader.state {
         case .failure(let error):
-            #expect(error is URLError)
+            #expect(error is KingfisherError)
         default:
             XCTFail("에러 상태가 되어야 한다.")
         }

--- a/EatPic-iOS/Tests/Image/ImageLoaderServiceTest.swift
+++ b/EatPic-iOS/Tests/Image/ImageLoaderServiceTest.swift
@@ -1,0 +1,83 @@
+//
+//  ImageLoaderServiceTest.swift
+//  EatPic-iOSTests
+//
+//  Created by jaewon Lee on 8/5/25.
+//
+
+import Testing
+import XCTest
+import UIKit
+import Kingfisher
+@testable import EatPic_iOS
+
+@Suite
+struct ImageLoaderServiceTest {
+
+    @Test("올바른 이미지 URL 로드 시 success 상태가 되어야 한다.")
+    func testSuccessfulImageLoad() async throws {
+        // given
+        let loader = ImageLoaderServiceImpl()
+        let urlString = """
+                https://upload.wikimedia.org/
+                wikipedia/commons/thumb/3/3c/
+                Shaki_waterfall.jpg/320px-Shaki_waterfall.jpg
+                """
+        
+        // when
+        loader.loadImage(from: urlString)
+        try await Task.sleep(nanoseconds: 2_000_000_000)
+        
+        // then
+        switch loader.state {
+        case .success(let image):
+            #expect(image.size.width > 0)
+        default:
+            XCTFail("이미지 로드 실패: \(loader.state)")
+        }
+    }
+
+    @Test("잘못된 URL을 입력하면 failure 상태가 되어야 한다.")
+    func testInvalidURL() {
+        // given
+        let loader = ImageLoaderServiceImpl()
+        
+        // when
+        loader.loadImage(from: "valid url")
+        
+        // then
+        switch loader.state {
+        case .failure(let error):
+            #expect(error is URLError)
+        default:
+            XCTFail("에러 상태가 되어야 한다.")
+        }
+    }
+    
+    @Test("이미 캐시된 이미지를 로드하면 success 상태가 되어야 한다.")
+    func testCachedImageLoad() async throws {
+        // given
+        let loader = ImageLoaderServiceImpl()
+        let cache = ImageCache.default
+        let testKey = "https://example.com/cached_image.jpg"
+        
+        // when
+        // 테스트용 이미지 (1x1 pixel)
+        guard let dummyImage = UIImage(systemName: "checkmark") else {
+            return
+        }
+        try await cache.store(dummyImage, forKey: testKey)
+        
+        loader.loadImage(from: testKey)
+        
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        
+        // then
+        switch loader.state {
+        case .success(let image):
+            #expect(image.size != .zero)
+        default:
+            XCTFail("캐시 이미지 로드 실패")
+        }
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
<!-- [ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ] -->
### 1. ImageLoaderService 및 구현체(ImageLoaderServiceImpl) 제작
- 이미지 URL을 입력받아 Kingfisher 기반으로 비동기 다운로드
- 이미지 다운로드 상태를 나타내는 ImageLoadState 정의 및 상태 관리
- cancel() 지원을 통해 이미지 다운로드 중단 기능 구현

### 2. 테스트 코드 작성
- ImageLoaderService의 정상 응답, 실패 응답에 대한 테스트 케이스 작성
- 테스트 통과 확인

### 3. NetworkImageView 제작
- 내부에서 ImageLoaderService 사용하여 이미지 다운로드 및 캐싱
- `.loading,` `.success`, `.failure` 상태에 따른 렌더링 분기 처리

### 4. SwiftDoc 주석 작성
- ImageLoaderService, ImageLoaderServiceImpl, ImageLoadState, NetworkImageView 전반에 주석 작성
- 사용법 및 역할에 대한 가이드를 명확히 제공하기 위해 SwiftDoc 스타일로 통일

### 5. async/await 기반 리팩토링
- 기존 Combine/클로저 기반의 loadImage(for:) → Swift Concurrency로 리팩토링
- KingfisherManager.shared.retrieveImage() 래핑: withCheckedThrowingContinuation 활용

### 6. 폴더 구조 이동
- NetworkImageView를 Component/Image 폴더 하위로 이동
- 컴포넌트/서비스 계층 구조 분리를 위한 폴더 구조 개선

## 📋 추후 진행 상황
<!-- [ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ] -->
- 이미지 로드 실패시 현재 텍스트로만 표현하도록 해놨는데, 추후 이미지로 변경 예정

## 📌 리뷰 포인트
<!-- [ 어떤 부분을 잘 체크해야하는지 작성해주세요 ] -->

## ✒️ 관련 이슈
<!-- ex) closes #15 -->
close #89 

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
