### PR TITLE
✨ [Feat] community 탭 모달뷰 구현

### DIFF
--- a/EatPic-iOS/Sources/Models/Community/CommunityModel.swift
+++ b/EatPic-iOS/Sources/Models/Community/CommunityModel.swift
@@ -39,7 +39,7 @@ struct Comment: Identifiable {
 
 // MARK: - Sample Data
 
-let sampleUsers: [CommunityUser] = [
+var sampleUsers: [CommunityUser] = [
     CommunityUser(id: "전체", nickname: "전체",
                   imageName: "Community/grid_selected", isCurrentUser: false, isFollowed: false),
     CommunityUser(id: "나", nickname: "나", imageName: nil, isCurrentUser: true, isFollowed: false),
@@ -55,7 +55,7 @@ let sampleUsers: [CommunityUser] = [
                   isCurrentUser: false, isFollowed: true)
 ]
 
-let sampleCards: [PicCard] = [
+var sampleCards: [PicCard] = [
     PicCard(user: sampleUsers[1], time: "오후 6:30",
             image: Image("Community/testImage"), memo: "오늘은 샐러드를 먹었습니다~"),
     PicCard(user: sampleUsers[2], time: "오후 5:20",
@@ -72,7 +72,7 @@ let sampleCards: [PicCard] = [
             image: Image("Community/testImage3"), memo: "오랜만에 피자 먹음")
 ]
 
-let sampleComments: [Comment] = [
+var sampleComments: [Comment] = [
     Comment(user: sampleUsers[1], text: "정말 맛있어 보이네요! 🤤", time: "10분 전"),
     Comment(user: sampleUsers[2], text: "어디서 먹을 수 있나요?", time: "5분 전"),
     Comment(user: sampleUsers[3], text: "레시피 공유해주세요~", time: "1분 전"),

--- a/EatPic-iOS/Sources/Models/Community/CommunityModel.swift
+++ b/EatPic-iOS/Sources/Models/Community/CommunityModel.swift
@@ -19,6 +19,7 @@ struct CommunityUser: Identifiable, Hashable, Equatable {
         imageName.map { Image($0) }
     }
     let isCurrentUser: Bool
+    var isFollowed: Bool
 }
 
 struct PicCard: Identifiable {
@@ -40,13 +41,18 @@ struct Comment: Identifiable {
 
 let sampleUsers: [CommunityUser] = [
     CommunityUser(id: "전체", nickname: "전체",
-                  imageName: "Community/grid_selected", isCurrentUser: false),
-    CommunityUser(id: "나", nickname: "나", imageName: nil, isCurrentUser: true),
-    CommunityUser(id: "id1", nickname: "아이디1", imageName: nil, isCurrentUser: false),
-    CommunityUser(id: "id2", nickname: "아이디2", imageName: nil, isCurrentUser: false),
-    CommunityUser(id: "id3", nickname: "아이디3", imageName: nil, isCurrentUser: false),
-    CommunityUser(id: "id4", nickname: "아이디4", imageName: nil, isCurrentUser: false),
-    CommunityUser(id: "id5", nickname: "아이디5", imageName: nil, isCurrentUser: false)
+                  imageName: "Community/grid_selected", isCurrentUser: false, isFollowed: false),
+    CommunityUser(id: "나", nickname: "나", imageName: nil, isCurrentUser: true, isFollowed: false),
+    CommunityUser(id: "id1", nickname: "아이디1", imageName: nil,
+                  isCurrentUser: false, isFollowed: true),
+    CommunityUser(id: "id2", nickname: "아이디2", imageName: nil,
+                  isCurrentUser: false, isFollowed: true),
+    CommunityUser(id: "id3", nickname: "아이디3", imageName: nil,
+                  isCurrentUser: false, isFollowed: true),
+    CommunityUser(id: "id4", nickname: "아이디4", imageName: nil,
+                  isCurrentUser: false, isFollowed: true),
+    CommunityUser(id: "id5", nickname: "아이디5", imageName: nil,
+                  isCurrentUser: false, isFollowed: true)
 ]
 
 let sampleCards: [PicCard] = [
@@ -63,7 +69,7 @@ let sampleCards: [PicCard] = [
     PicCard(user: sampleUsers[2], time: "오후 3:10",
             image: Image("Community/testImage2"), memo: "아침엔 스무디 먹음"),
     PicCard(user: sampleUsers[2], time: "오후 2:00",
-            image: Image("Community/testImage3"), memo: "오랜만에 피자 먹음"),
+            image: Image("Community/testImage3"), memo: "오랜만에 피자 먹음")
 ]
 
 let sampleComments: [Comment] = [

--- a/EatPic-iOS/Sources/Screens/Community/ViewModels/BlockedUsersManager.swift
+++ b/EatPic-iOS/Sources/Screens/Community/ViewModels/BlockedUsersManager.swift
@@ -1,0 +1,33 @@
+//
+//  BlockedUsersManager.swift
+//  EatPic-iOS
+//
+//  Created by 원주연 on 8/9/25.
+//
+
+import Foundation
+
+@Observable
+final class BlockedUsersManager {
+    static let shared = BlockedUsersManager()
+    
+    private(set) var blockedUserIds: Set<String> = []
+    
+    private init() {}
+    
+    func blockUser(userId: String) {
+        blockedUserIds.insert(userId)
+        print("사용자 차단됨: \(userId)")
+        // TODO: 실제 서버에 차단 API 호출
+    }
+    
+    func unblockUser(userId: String) {
+        blockedUserIds.remove(userId)
+        print("사용자 차단 해제됨: \(userId)")
+        // TODO: 실제 서버에 차단 해제 API 호출
+    }
+    
+    func isBlocked(userId: String) -> Bool {
+        return blockedUserIds.contains(userId)
+    }
+}

--- a/EatPic-iOS/Sources/Screens/Community/ViewModels/CommentViewModel.swift
+++ b/EatPic-iOS/Sources/Screens/Community/ViewModels/CommentViewModel.swift
@@ -20,7 +20,7 @@ final class CommentViewModel {
     // 현재 로그인된 사용자의 정보 (임시)
     private let currentUser = CommunityUser(
         id: "itcong", nickname: "잇콩",
-        imageName: "Community/itcong", isCurrentUser: true)
+        imageName: "Community/itcong", isCurrentUser: true, isFollowed: true)
     
     func postComment() {
         guard !commentText.isEmpty else { return }

--- a/EatPic-iOS/Sources/Screens/Community/ViewModels/CommunityMainViewModel.swift
+++ b/EatPic-iOS/Sources/Screens/Community/ViewModels/CommunityMainViewModel.swift
@@ -21,13 +21,30 @@ final class CommunityMainViewModel {
     let toastVM = ToastViewModel()
     
     // MARK: - Computed Properties
-    var filteredCards: [PicCard] {
-        if selectedUser.nickname == "전체" {
-            return sampleCards
-        } else {
-            return sampleCards.filter { $0.user == selectedUser }
+    /// 차단되지 않은 유저들만 필터링한 목록
+        var filteredUsers: [CommunityUser] {
+            return sampleUsers.filter { user in
+                // "전체" 사용자는 항상 포함
+                if user.id == "전체" {
+                    return true
+                }
+                // 차단되지 않은 유저만 포함
+                return !BlockedUsersManager.shared.isBlocked(userId: user.id)
+            }
         }
-    }
+    
+    /// 선택된 유저에 따라 필터링된 카드 목록 (차단된 유저 제외)
+        var filteredCards: [PicCard] {
+            let nonBlockedCards = sampleCards.filter { card in
+                !BlockedUsersManager.shared.isBlocked(userId: card.user.id)
+            }
+            
+            if selectedUser.nickname == "전체" {
+                return nonBlockedCards
+            } else {
+                return nonBlockedCards.filter { $0.user == selectedUser }
+            }
+        }
     
     // MARK: - Actions
     func selectUser(_ user: CommunityUser) {

--- a/EatPic-iOS/Sources/Screens/Community/ViewModels/CommunityMainViewModel.swift
+++ b/EatPic-iOS/Sources/Screens/Community/ViewModels/CommunityMainViewModel.swift
@@ -15,6 +15,8 @@ final class CommunityMainViewModel {
     var selectedUser: CommunityUser = sampleUsers[0]
     var isShowingReportBottomSheet = false
     var isShowingCommentBottomSheet = false
+    var showDeleteModal = false
+    private var cardToDelete: PicCard?
     
     let toastVM = ToastViewModel()
     
@@ -51,32 +53,53 @@ final class CommunityMainViewModel {
     }
     
     // PicCard의 메뉴 액션을 처리하는 함수 (예시)
-        func saveCardToPhotos(_ card: PicCard) {
-            toastVM.showToast(title: "사진 앱에 저장되었습니다.")
-            print("사진 앱에 저장: \(card.id)")
-            // TODO: - UIImageWriteToSavedPhotosAlbum 등을 이용한 실제 저장 로직 구현
+    func saveCardToPhotos(_ card: PicCard) {
+        toastVM.showToast(title: "사진 앱에 저장되었습니다.")
+        print("사진 앱에 저장: \(card.id)")
+        // TODO: - UIImageWriteToSavedPhotosAlbum 등을 이용한 실제 저장 로직 구현
+    }
+    
+    func editCard(_ card: PicCard) {
+        print("수정하기: \(card.id)")
+        // TODO: - 카드 수정 화면으로 이동하는 로직 구현
+    }
+    
+    func showDeleteConfirmation(for card: PicCard) {
+            self.cardToDelete = card
+            self.showDeleteModal = true
+            print("삭제 확인 모달 띄우기: \(card.id)")
         }
-
-        func editCard(_ card: PicCard) {
-            print("수정하기: \(card.id)")
-            // TODO: - 카드 수정 화면으로 이동하는 로직 구현
+    
+    // 모달에서 '삭제' 버튼을 눌렀을 때 실제 삭제를 처리하는 함수
+        func confirmDeletion() {
+            guard let card = cardToDelete else { return }
+            
+            // TODO: - 실제 삭제 API 호출 로직 구현
+            if let index = sampleCards.firstIndex(where: { $0.id == card.id }) {
+                sampleCards.remove(at: index)
+            }
+            
+            showDeleteModal = false
+            cardToDelete = nil
+            toastVM.showToast(title: "삭제되었습니다.")
+            print("카드 삭제 완료: \(card.id)")
         }
-
-        func deleteCard(_ card: PicCard) {
-            // TODO: - 뱃지 뷰 구현
-            print("삭제하기: \(card.id)")
-            // TODO: - 카드 삭제 로직 구현
-        }
-
-        func reportCard(_ card: PicCard) {
-            print("신고하기: \(card.id)")
-            // TODO: - 신고 바텀시트 띄우는 로직 구현 (아래에서 수정)
-        }
-
-        // PicCard의 작성자가 현재 사용자인지 확인하는 메서드
-        func isMyCard(_ card: PicCard) -> Bool {
-            // TODO: - 실제 현재 사용자 ID와 비교하는 로직으로 변경
-            // 예시: return card.user.id == currentUser.id
-            return card.user.id == "나" // 임시 로직
-        }
+    
+    func deleteCard(_ card: PicCard) {
+        // TODO: - 뱃지 뷰 구현
+        print("삭제하기: \(card.id)")
+        // TODO: - 카드 삭제 로직 구현
+    }
+    
+    func reportCard(_ card: PicCard) {
+        print("신고하기: \(card.id)")
+        // TODO: - 신고 바텀시트 띄우는 로직 구현 (아래에서 수정)
+    }
+    
+    // PicCard의 작성자가 현재 사용자인지 확인하는 메서드
+    func isMyCard(_ card: PicCard) -> Bool {
+        // TODO: - 실제 현재 사용자 ID와 비교하는 로직으로 변경
+        // 예시: return card.user.id == currentUser.id
+        return card.user.id == "나" // 임시 로직
+    }
 }

--- a/EatPic-iOS/Sources/Screens/Community/ViewModels/FollowListViewModel.swift
+++ b/EatPic-iOS/Sources/Screens/Community/ViewModels/FollowListViewModel.swift
@@ -1,0 +1,72 @@
+//
+//  FollowListViewModel.swift
+//  EatPic-iOS
+//
+//  Created by 원주연 on 8/8/25.
+//
+
+import Foundation
+
+@Observable
+final class FollowListViewModel {
+    
+    var selected: FollowListView.FollowSegment
+    var searchText: String = ""
+    private var followers: [CommunityUser] = sampleFollowers
+    private var followings: [CommunityUser] = sampleFollowings
+    
+    init(selected: FollowListView.FollowSegment) {
+        self.selected = selected
+    }
+    
+    var filteredUsers: [CommunityUser] {
+        let list = selected == .followers ? followers : followings
+        if searchText.isEmpty {
+            return list
+        } else {
+            return list.filter {
+                $0.nickname.localizedCaseInsensitiveContains(searchText) ||
+                $0.id.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+    }
+    
+    func userCount(for segment: FollowListView.FollowSegment) -> Int {
+        switch segment {
+        case .followers:
+            return followers.count
+        case .followings:
+            return followings.count
+        }
+    }
+    
+    func toggleFollow(for user: CommunityUser) {
+        if selected == .followers {
+            if let index = followers.firstIndex(where: { $0.id == user.id }) {
+                // 모델의 isFollowed 속성을 직접 토글합니다.
+                followers[index].isFollowed.toggle()
+            }
+        } else {
+            if let index = followings.firstIndex(where: { $0.id == user.id }) {
+                // 모델의 isFollowed 속성을 직접 토글합니다.
+                followings[index].isFollowed.toggle()
+            }
+        }
+    }
+}
+
+// MARK: - Updated Sample Data (For FollowListView)
+
+let sampleFollowers: [CommunityUser] = [
+    CommunityUser(id: "hong", nickname: "홍길동", imageName: nil,
+                  isCurrentUser: false, isFollowed: true),
+    CommunityUser(id: "young", nickname: "김영희", imageName: nil,
+                  isCurrentUser: false, isFollowed: false)
+]
+
+let sampleFollowings: [CommunityUser] = [
+    CommunityUser(id: "cheolsoo", nickname: "이철수", imageName: nil,
+                  isCurrentUser: false, isFollowed: true),
+    CommunityUser(id: "minsu", nickname: "박민수", imageName: nil,
+                  isCurrentUser: false, isFollowed: true)
+]

--- a/EatPic-iOS/Sources/Screens/Community/ViewModels/OthersProfileViewModel.swift
+++ b/EatPic-iOS/Sources/Screens/Community/ViewModels/OthersProfileViewModel.swift
@@ -1,0 +1,66 @@
+//
+//  OthersProfileViewModel.swift
+//  EatPic-iOS
+//
+//  Created by 원주연 on 8/8/25.
+//
+
+import Foundation
+
+@Observable
+final class OthersProfileViewModel {
+    var user: CommunityUser
+    var isFollowed: Bool = false
+    var showBlockModal: Bool = false
+    var isShowingReportBottomSheet: Bool = false
+    
+    private var allUsers: [CommunityUser] = sampleUsers
+    private var allPicCards: [PicCard] = sampleCards
+    
+    var picCardCount: Int {
+        allPicCards.filter { $0.user.id == user.id }.count
+    }
+    
+    var followerCount: Int {
+        // 더미 데이터에는 팔로워 정보가 없으므로 임의의 값 반환
+        return 2
+    }
+    
+    var followingCount: Int {
+        // 더미 데이터에는 팔로잉 정보가 없으므로 임의의 값 반환
+        return 2
+    }
+    
+    var userCards: [PicCard] {
+        allPicCards.filter { $0.user.id == user.id }
+    }
+    
+    init(user: CommunityUser) {
+        self.user = user
+        self.isFollowed = checkFollowStatus(for: user)
+    }
+    
+    func toggleFollow() {
+        // TODO: 실제 팔로우/언팔로우 API 호출 로직 구현
+        isFollowed.toggle()
+        print("\(user.nickname) 팔로우 상태 변경: \(isFollowed)")
+    }
+    
+    func blockUser() {
+        // TODO: 실제 차단 API 호출 로직 구현
+        isFollowed = false
+        print("\(user.nickname) 차단 완료")
+    }
+    
+    func handleProfileReport(_ reportType: String) {
+        print("프로필 신고: \(user.id) - 유형: \(reportType)")
+        // TODO: 실제 신고 API 호출 로직 구현
+        isShowingReportBottomSheet = false
+    }
+    
+    private func checkFollowStatus(for user: CommunityUser) -> Bool {
+        // TODO: 실제 팔로우 상태를 확인하는 로직 구현 (API 호출 등)
+        // 현재는 더미 데이터로 임시 구현
+        return user.id == "id3" ? true : false
+    }
+}

--- a/EatPic-iOS/Sources/Screens/Community/ViewModels/OthersProfileViewModel.swift
+++ b/EatPic-iOS/Sources/Screens/Community/ViewModels/OthersProfileViewModel.swift
@@ -47,7 +47,8 @@ final class OthersProfileViewModel {
     }
     
     func blockUser() {
-        // TODO: 실제 차단 API 호출 로직 구현
+        // BlockedUsersManager를 통해 차단 처리
+        BlockedUsersManager.shared.blockUser(userId: user.id)
         isFollowed = false
         print("\(user.nickname) 차단 완료")
     }

--- a/EatPic-iOS/Sources/Screens/Community/ViewModels/OthersProfileViewModel.swift
+++ b/EatPic-iOS/Sources/Screens/Community/ViewModels/OthersProfileViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 @Observable
 final class OthersProfileViewModel {
     var user: CommunityUser
-    var isFollowed: Bool = false
+    var isFollowed: Bool = true
     var showBlockModal: Bool = false
     var isShowingReportBottomSheet: Bool = false
     

--- a/EatPic-iOS/Sources/Screens/Community/Views/CommunityMainView.swift
+++ b/EatPic-iOS/Sources/Screens/Community/Views/CommunityMainView.swift
@@ -60,7 +60,7 @@ struct CommunityMainView: View {
     private func userListView() -> some View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: 16) {
-                ForEach(sampleUsers) { user in
+                ForEach(viewModel.filteredUsers) { user in
                     VStack(spacing: 16) {
                         ProfileImageView(
                             image: user.profileImage,

--- a/EatPic-iOS/Sources/Screens/Community/Views/CommunityMainView.swift
+++ b/EatPic-iOS/Sources/Screens/Community/Views/CommunityMainView.swift
@@ -13,29 +13,47 @@ struct CommunityMainView: View {
     @State private var viewModel = CommunityMainViewModel()
     
     var body: some View {
-        ScrollView {
-            VStack(spacing: 40) {
-                userListView()
-                cardListView()
-                lastContentView()
+        ZStack {
+            ScrollView {
+                VStack(spacing: 40) {
+                    userListView()
+                    cardListView()
+                    lastContentView()
+                }
             }
-        }
-        .scrollIndicators(.hidden)
-        .toastView(viewModel: viewModel.toastVM)
-        .padding(.horizontal, 16)
-        .sheet(isPresented: $viewModel.isShowingReportBottomSheet) {
-            ReportBottomSheetView(
-                isShowing: $viewModel.isShowingReportBottomSheet,
-                onReport: viewModel.handleReport,
-                target: .picCard
-            )
-            .presentationDetents([.large, .fraction(0.7)])
-            .presentationDragIndicator(.hidden)
-        }
-        .sheet(isPresented: $viewModel.isShowingCommentBottomSheet) {
-            CommentBottomSheetView(isShowing: $viewModel.isShowingCommentBottomSheet)
+            .scrollIndicators(.hidden)
+            .toastView(viewModel: viewModel.toastVM)
+            .padding(.horizontal, 16)
+            .sheet(isPresented: $viewModel.isShowingReportBottomSheet) {
+                ReportBottomSheetView(
+                    isShowing: $viewModel.isShowingReportBottomSheet,
+                    onReport: viewModel.handleReport,
+                    target: .picCard
+                )
                 .presentationDetents([.large, .fraction(0.7)])
                 .presentationDragIndicator(.hidden)
+            }
+            .sheet(isPresented: $viewModel.isShowingCommentBottomSheet) {
+                CommentBottomSheetView(isShowing: $viewModel.isShowingCommentBottomSheet)
+                    .presentationDetents([.large, .fraction(0.7)])
+                    .presentationDragIndicator(.hidden)
+            }
+            
+            if viewModel.showDeleteModal {
+                DecisionModalView(
+                    message: "Pic카드를 정말 삭제하시겠어요?",
+                    messageColor: .gray080,
+                    leftBtnText: "취소",
+                    rightBtnText: "삭제",
+                    rightBtnColor: .pink070,
+                    leftBtnAction: {
+                        viewModel.showDeleteModal = false
+                    },
+                    rightBtnAction: {
+                        viewModel.confirmDeletion()
+                    }
+                )
+            }
         }
     }
     
@@ -77,23 +95,30 @@ struct CommunityMainView: View {
                     menuContent: {
                         if viewModel.isMyCard(card) {
                             // 내가 작성한 카드일 때
-                            Button(action: { viewModel.saveCardToPhotos(card) }) {
+                            Button(action: {
+                                viewModel.saveCardToPhotos(card)
+                            }, label: {
                                 Label("사진 앱에 저장", systemImage: "arrow.down.to.line")
-                            }
-                            Button(action: { viewModel.editCard(card) }) {
+                            })
+                            Button(action: {
+                                viewModel.editCard(card)
+                            }, label: {
                                 Label("수정하기", systemImage: "square.and.pencil")
-                            }
-                            Button(role: .destructive, action: { viewModel.deleteCard(card) }) {
+                            })
+                            Button(role: .destructive,
+                                   action: {
+                                viewModel.showDeleteConfirmation(for: card)
+                            }, label: {
                                 Label("삭제하기", systemImage: "trash")
-                            }
+                            })
                         } else {
                             // 다른 사람이 작성한 카드일 때
                             Button(role: .destructive, action: {
                                 viewModel.isShowingReportBottomSheet = true
                                 print("신고하기")
-                            }) {
+                            }, label: {
                                 Label("신고하기", systemImage: "exclamationmark.bubble")
-                            }
+                            })
                         }
                     },
                     postImage: card.image,

--- a/EatPic-iOS/Sources/Screens/Community/Views/FollowListView.swift
+++ b/EatPic-iOS/Sources/Screens/Community/Views/FollowListView.swift
@@ -25,58 +25,20 @@ struct FollowListView: View {
         case followings = "팔로잉"
     }
     // MARK: - Properties
+    @State private var viewModel: FollowListViewModel
     @Namespace var name
-    @State private var selected: FollowSegment
-    @State private var searchText = ""
-    
-    // 샘플 팔로워 유저 리스트
-    @State private var followers: [User] = [
-        User(
-            id: UUID(),
-            profileImage: nil,
-            nickname: "홍길동",
-            userId: "@hong",
-            isFollow: true
-        ),
-        User(
-            id: UUID(),
-            profileImage: nil,
-            nickname: "김영희",
-            userId: "@young",
-            isFollow: false
-        )
-    ]
-    
-    // 샘플 팔로잉 유저 리스트
-    @State private var followings: [User] = [
-        User(
-            id: UUID(),
-            profileImage: nil,
-            nickname: "이철수",
-            userId: "@cheolsoo",
-            isFollow: true
-        ),
-        User(
-            id: UUID(),
-            profileImage: nil,
-            nickname: "박민수",
-            userId: "@minsu",
-            isFollow: true
-        )
-    ]
     
     init(selected: FollowSegment) {
-        _selected = State(initialValue: selected)
-    }
+            self._viewModel = State(initialValue: FollowListViewModel(selected: selected))
+        }
     
     // MARK: - Body
-    
     var body: some View {
         VStack {
             segmentedView() // 상단 탭
             
             SearchBarView( // 검색창
-                text: $searchText,
+                text: $viewModel.searchText,
                 placeholder: "닉네임 또는 아이디로 검색",
                 showsDeleteButton: false,
                 backgroundColor: .gray020,
@@ -106,19 +68,19 @@ struct FollowListView: View {
         HStack(spacing: 0) {
             ForEach(FollowSegment.allCases, id: \.self) { segment in
                 Button {
-                    selected = segment
+                    viewModel.selected = segment
                 } label: {
                     VStack {
-                        Text("\(userCount(for: segment)) \(segment.rawValue)")
+                        Text("\(viewModel.userCount(for: segment)) \(segment.rawValue)")
                             .font(.footnote)
                             .fontWeight(.medium)
-                            .foregroundStyle(selected == segment ?
+                            .foregroundStyle(viewModel.selected == segment ?
                                              Color.gray080 : Color.gray050)
                         ZStack {
                             Capsule()
                                 .fill(Color.clear)
                                 .frame(height: 4)
-                            if selected == segment {
+                            if viewModel.selected == segment {
                                 Capsule()
                                     .fill(Color.gray080)
                                     .frame(height: 2)
@@ -136,38 +98,12 @@ struct FollowListView: View {
         }
     }
     
-    /// 각 탭별 유저 수 계산
-    private func userCount(for segment: FollowSegment) -> Int {
-        switch segment {
-        case .followers:
-            return followers.count
-        case .followings:
-            return followings.count
-        }
-    }
-    
-    // MARK: - Filtered User List
-    
-    /// 검색어에 따라 필터링된 유저 리스트
-    private var filteredUsers: [User] {
-        let list = selected == .followers ? followers : followings
-        if searchText.isEmpty {
-            return list
-        } else {
-            return list.filter {
-                $0.nickname.localizedCaseInsensitiveContains(searchText) ||
-                $0.userId.localizedCaseInsensitiveContains(searchText)
-            }
-        }
-    }
-    
     // MARK: - User List View
-        
     /// 필터링된 유저 리스트를 보여주는 ScrollView
     private func userListView() -> some View {
         ScrollView {
             LazyVStack(spacing: 20) {
-                ForEach(filteredUsers) { user in
+                ForEach(viewModel.filteredUsers) { user in
                     userRowView(user: user)
                 }
             }
@@ -175,7 +111,7 @@ struct FollowListView: View {
     }
     
     /// 한 명의 유저를 표시하는 행 뷰
-    private func userRowView(user: User) -> some View {
+    private func userRowView(user: CommunityUser) -> some View {
         HStack(spacing: 16) {
             ProfileImageView(image: user.profileImage, size: 47)
             
@@ -183,14 +119,14 @@ struct FollowListView: View {
                 Text(user.nickname)
                     .font(.dsSubhead)
                     .foregroundStyle(Color.black)
-                Text(user.userId)
+                Text(user.id)
                     .font(.dsSubhead)
                     .foregroundStyle(Color.gray060)
             }
             
             Spacer()
             
-            if user.isFollow {
+            if user.isFollowed {
                 PrimaryButton(
                     color: .gray030,
                     text: "팔로잉",
@@ -200,7 +136,7 @@ struct FollowListView: View {
                     height: 28,
                     cornerRadius: 5,
                     action: {
-                        toggleFollow(for: user)
+                        viewModel.toggleFollow(for: user)
                     }
                 )
             } else {
@@ -213,25 +149,13 @@ struct FollowListView: View {
                     height: 28,
                     cornerRadius: 5,
                     action: {
-                        toggleFollow(for: user)
+                        viewModel.toggleFollow(for: user)
                     }
                 )
             }
         }
     }
-    
-    /// 팔로우 상태 토글 로직
-    private func toggleFollow(for user: User) {
-        if selected == .followers {
-            if let index = followers.firstIndex(where: { $0.id == user.id }) {
-                followers[index].isFollow.toggle()
-            }
-        } else {
-            if let index = followings.firstIndex(where: { $0.id == user.id }) {
-                followings[index].isFollow.toggle()
-            }
-        }
-    }
+
 }
 
 #Preview {

--- a/EatPic-iOS/Sources/Screens/Community/Views/OthersProfileView.swift
+++ b/EatPic-iOS/Sources/Screens/Community/Views/OthersProfileView.swift
@@ -251,6 +251,7 @@ struct OthersProfileView: View {
         id: "id1",
         nickname: "아이디1",
         imageName: nil,
-        isCurrentUser: true
+        isCurrentUser: true,
+        isFollowed: true
     ))
 }


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
<!-- [ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ] -->
![Simulator Screen Recording - iPhone 16 - 2025-08-09 at 13 52 55](https://github.com/user-attachments/assets/a5fc2574-010d-479d-b48c-a51a15d31ac4)

### 1. 특정 유저 차단
- '차단하시겠습니까?' 모달뷰 구현
- '차단되었습니다' 토스트뷰 구현
- 차단 후 유저리스트에서 해당 유저 사라짐
- 차단 후 전체 카드리스트에서 해당 유저의 카드 더 이상 안 보임

### 2. 나의 픽카드 삭제
- '삭제하시겠습니까?' 모달뷰 구현
- '삭제되었습니다' 토스트뷰 구현
- 삭제되어 더이상 커뮤니티 탭에서 보이지 않음

## 📋 추후 진행 상황
<!-- [ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ] -->

## 📌 리뷰 포인트
<!-- [ 어떤 부분을 잘 체크해야하는지 작성해주세요 ] -->
- ❗️ 이슈 있습니다
- 유저 차단 후, 프로필 뷰가 닫힌 뒤 커뮤니티 메인뷰에서 '차단되었습니다' 하는 토스트뷰가 떠야 함
- 그런데 구현 방법을 몰라서 임시로 프로필뷰에서 토스트뷰 띄운 뒤 2초 뒤 자동으로 프로필 뷰가 닫히도록 구현함
- 흑흑 오랫동안 고민해보고 지피티, 클로드, 제미나이 다 괴롭혀봤는데 라우터 수정해야되고 이래서 임시로 구현했습니다.. 남은 기능이 많아서,,ㅎ

## ✒️ 관련 이슈
<!-- ex) closes #15 -->
closes #122 

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
