### PR TITLE
✨ [Feat] reaction 삭제 API

### DIFF
--- a/EatPic-iOS/Sources/Components/Card/PicCardItemView.swift
+++ b/EatPic-iOS/Sources/Components/Card/PicCardItemView.swift
@@ -127,7 +127,7 @@ struct PicCardItemView: View {
             withAnimation {
                 isShowingReactionBar = true
             }
-            onAction?(.reaction(selected: selectedReaction, counts: reactionCounts))
+            //            onAction?(.reaction(selected: selectedReaction, counts: reactionCounts))
         }
     }
     
@@ -141,7 +141,6 @@ struct PicCardItemView: View {
         }
     }
     
-    /// 리액션 선택 처리
     private func handleReactionSelection(_ reaction: ReactionType?) {
         let previousReaction = selectedReaction
         selectedReaction = reaction

--- a/EatPic-iOS/Sources/Core/Networks/DTO/Response/Reaction/ReactionUserListResult.swift
+++ b/EatPic-iOS/Sources/Core/Networks/DTO/Response/Reaction/ReactionUserListResult.swift
@@ -1,0 +1,27 @@
+//
+//  ReactionUserListResult.swift
+//  EatPic-iOS
+//
+//  Created by 원주연 on 8/20/25.
+//
+import Foundation
+
+struct ReactionUserListResult: Codable {
+    let cardId: Int
+    let reactionType: ReactionType
+    let page: Int
+    let size: Int
+    let total: Int
+    let userList: [ReactionUser]
+}
+
+struct ReactionUser: Codable, Identifiable {
+    let userId: Int
+    let profileImageUrl: String
+    let nameId: String
+    let nickname: String
+    let introduce: String
+    let isFollowing: Bool
+    
+    var id: Int { userId }
+}

--- a/EatPic-iOS/Sources/Core/Networks/TargetType/Reaction/ReactionTargetType.swift
+++ b/EatPic-iOS/Sources/Core/Networks/TargetType/Reaction/ReactionTargetType.swift
@@ -9,7 +9,7 @@ import Foundation
 import Moya
 
 enum ReactionTargetType {
-    case postReaction(cardId: Int, reactionType: ReactionTypes)
+    case postReaction(cardId: Int, reactionType: String)
     case getReactionUsers(cardId: Int, reactionType: ReactionType, page: Int, size: Int)
 }
 
@@ -17,9 +17,9 @@ extension ReactionTargetType: APITargetType {
     var path: String {
         switch self {
         case .postReaction(let cardId, let reactionType):
-            return "/api/reactions/\(cardId)/\(reactionType.rawValue)"
+            return "/api/reactions/\(cardId)/\(reactionType)"
         case .getReactionUsers(let cardId, let reactionType, _, _):
-            return "/api/reactions/\(cardId)/\(reactionType.rawValue)/users"
+            return "/api/reactions/\(cardId)/\(reactionType)/users"
         }
     }
     

--- a/EatPic-iOS/Sources/Core/Networks/TargetType/Reaction/ReactionTargetType.swift
+++ b/EatPic-iOS/Sources/Core/Networks/TargetType/Reaction/ReactionTargetType.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum ReactionTargetType {
     case postReaction(cardId: Int, reactionType: ReactionTypes)
+    case getReactionUsers(cardId: Int, reactionType: ReactionType, page: Int, size: Int)
 }
 
 extension ReactionTargetType: APITargetType {
@@ -17,6 +18,8 @@ extension ReactionTargetType: APITargetType {
         switch self {
         case .postReaction(let cardId, let reactionType):
             return "/api/reactions/\(cardId)/\(reactionType.rawValue)"
+        case .getReactionUsers(let cardId, let reactionType, _, _):
+            return "/api/reactions/\(cardId)/\(reactionType.rawValue)/users"
         }
     }
     
@@ -24,6 +27,8 @@ extension ReactionTargetType: APITargetType {
         switch self {
         case .postReaction:
             return .post
+        case .getReactionUsers:
+            return .get
         }
     }
     
@@ -31,6 +36,14 @@ extension ReactionTargetType: APITargetType {
         switch self {
         case .postReaction(let cardId, let reactionType):
             return .requestPlain
+        case .getReactionUsers(_, _, let page, let size):
+            return .requestParameters(
+                parameters: [
+                    "page": page,
+                    "size": size
+                ],
+                encoding: URLEncoding.queryString
+            )
         }
     }
     


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
<!-- [ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ] -->

https://github.com/user-attachments/assets/8f7b28a1-76ee-4848-8460-808b2f5b1c30

### 1. 이슈에 작성했던 내용과 달라진 작업내용
- 해당 카드에 작성된 반응 별 유저정보 API를 구현하려고 했으나, 해당 API는 내 카드일 때, 각 반응별로 반응을 남긴 사람들 리스트를 보여주는 api인데 프론트에서 기능 구현이 안되어서 현재 구현하기 어렵다고 판단
- 해당 카드에 작성된 반응 별 유저정보 API는 targetType까지만 작성해놓음

### 2. reaction 삭제 API
- 이전에 재원이가 작업 마무리하여 머지한 반응 Post api로 반응 수정, 삭제까지 처리가능하여 처리하도록 수정
- 그러나, 이슈있음
- 원래 리액션 바에서 반응이 선택될 때 api가 불러져와야하는데, 일단 반응이 한번 설정되고 나면, 리액션 바가 아닌, 아이템 바에서 이모지 버튼만 눌러도 api가 호출되어, 프론트에서 보이는 상태와 서버에 저장되는 상태가 달라짐
- 이걸 해결하려고 꽤나 노력해봤지만 실패했습니다.

## 📋 추후 진행 상황
<!-- [ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ] -->

## 📌 리뷰 포인트
<!-- [ 어떤 부분을 잘 체크해야하는지 작성해주세요 ] -->

## ✒️ 관련 이슈
<!-- ex) closes #15 -->
closes #222 

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
